### PR TITLE
fix: fileSize do backend ajustado para 16MB

### DIFF
--- a/backend/src/routes/apiExternalRoutes.ts
+++ b/backend/src/routes/apiExternalRoutes.ts
@@ -11,7 +11,7 @@ const upload = multer({
   ...uploadConfig,
   limits: {
     files: 1, // allow only 1 file per request
-    fileSize: 1024 * 1024 * 5 // 5 MB (max file size)
+    fileSize: 1024 * 1024 * 16 // 16 MB (max file size)
   }
 
   // fileFilter: (req, file, cb) => {


### PR DESCRIPTION
O tamanho máximo permitido para o envio de arquivos foi ajustado de 5MB para 16MB - máximo permitido pelo WhatsApp.